### PR TITLE
test: e2e 테스트에서 chromium 제거

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,10 +34,11 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
-    {
-      name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
-    },
+    // https://github.com/microsoft/playwright/issues/6479
+    // {
+    //   name: "chromium",
+    //   use: { ...devices["Desktop Chrome"] },
+    // },
 
     {
       name: "firefox",


### PR DESCRIPTION
chromium에서 postData가 빈 오류 발생

참고: https://github.com/microsoft/playwright/issues/6479
